### PR TITLE
eta-expand runLogicT for GHC HEAD compatibility

### DIFF
--- a/Control/Monad/Logic.hs
+++ b/Control/Monad/Logic.hs
@@ -102,7 +102,7 @@ observeManyT n m
 -- | Runs a LogicT computation with the specified initial success and
 -- failure continuations.
 runLogicT :: LogicT m a -> (a -> m r -> m r) -> m r -> m r
-runLogicT = unLogicT
+runLogicT (LogicT r) = r
 
 -------------------------------------------------------------------------
 -- | The basic Logic monad, for performing backtracking computations


### PR DESCRIPTION
GHC HEAD (soon GHC 9) has some typechecker changes which was causing
the previous code fail to typecheck.

This is the type error:

```
Control/Monad/Logic.hs:105:13: error:
    • Couldn't match type: forall r1.
                           (a -> m r1 -> m r1) -> m r1 -> m r1
                     with: (a -> m r -> m r) -> m r -> m r
      Expected: LogicT m a -> (a -> m r -> m r) -> m r -> m r
        Actual: LogicT m a -> forall r. (a -> m r -> m r) -> m r -> m r
    • In the expression: unLogicT
      In an equation for ‘runLogicT’: runLogicT = unLogicT
    • Relevant bindings include
        runLogicT :: LogicT m a -> (a -> m r -> m r) -> m r -> m r
          (bound at Control/Monad/Logic.hs:105:1)
    |
105 | runLogicT = unLogicT
    |             ^^^^^^^^
```

With this simple change it seems to be happy.