### PR TITLE
More tests

### DIFF
--- a/logict.cabal
+++ b/logict.cabal
@@ -51,5 +51,6 @@ test-suite logict-tests
     logict -any,
     mtl >=2 && <2.3,
     tasty,
-    tasty-hunit
+    tasty-hunit,
+    tasty-expected-failure >= 0.12 && < 0.13
   hs-source-dirs: test

--- a/logict.cabal
+++ b/logict.cabal
@@ -35,7 +35,7 @@ library
   ghc-options: -O2 -Wall
   build-depends:
     base >=2 && <5,
-    mtl
+    mtl >=2 && <2.3
 
   if impl(ghc <8.0)
     build-depends:

--- a/logict.cabal
+++ b/logict.cabal
@@ -35,7 +35,7 @@ library
   ghc-options: -O2 -Wall
   build-depends:
     base >=2 && <5,
-    mtl >=2.2.1 && <2.3
+    mtl
 
   if impl(ghc <8.0)
     build-depends:
@@ -49,7 +49,7 @@ test-suite logict-tests
   build-depends:
     base >=2 && <5,
     logict -any,
-    mtl >=2.2.1 && <2.3,
+    mtl,
     tasty,
     tasty-hunit
 

--- a/logict.cabal
+++ b/logict.cabal
@@ -51,6 +51,10 @@ test-suite logict-tests
     logict -any,
     mtl >=2 && <2.3,
     tasty,
-    tasty-hunit,
-    tasty-expected-failure >= 0.12
+    tasty-hunit
+
+  if impl(ghc >= 8.0)
+    build-depends:
+      tasty-expected-failure >= 0.12
+
   hs-source-dirs: test

--- a/logict.cabal
+++ b/logict.cabal
@@ -52,5 +52,5 @@ test-suite logict-tests
     mtl >=2 && <2.3,
     tasty,
     tasty-hunit,
-    tasty-expected-failure >= 0.12 && < 0.13
+    tasty-expected-failure >= 0.12
   hs-source-dirs: test

--- a/logict.cabal
+++ b/logict.cabal
@@ -35,7 +35,7 @@ library
   ghc-options: -O2 -Wall
   build-depends:
     base >=2 && <5,
-    mtl >=2 && <2.3
+    mtl >=2.2.1 && <2.3
 
   if impl(ghc <8.0)
     build-depends:
@@ -49,7 +49,7 @@ test-suite logict-tests
   build-depends:
     base >=2 && <5,
     logict -any,
-    mtl >=2 && <2.3,
+    mtl >=2.2.1 && <2.3,
     tasty,
     tasty-hunit
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -196,7 +196,21 @@ main = defaultMain $
         -- with fairness, the results are interleaved
 
       , testCase "fair disjunction :: LogicT"   $ [1,2,3,5] @=? observeMany 4 oddsOrTwoFair
-      , testCase "fair termination"   $ [2] @=? observeT oddsOrTwo
+
+        -- without fairness nothing would be produced, but with
+        -- fairness, a production is obtained
+
+      , testCase "fair production"   $ [2] @=? observeT oddsOrTwo
+
+        -- however, asking for additional productions will not
+        -- terminate (there are none, since the first clause generates
+        -- an infinity of mzero "failures")
+
+      , expectFail $ testCase "nontermination even when fair" $
+        [[2]] @=? observeManyT 2 oddsOrTwo
+
+        -- Validate fair disjunction works for other
+        -- Control.Monad.Logic.Class instances
 
       , testCase "fair disjunction :: []" $ [1,2,3,5] @=?
         (take 4 $ let oddsL = [ 1::Integer ] `mplus` [ o | o <- [3..], odd o ]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -8,7 +8,6 @@ import           Test.Tasty.HUnit
 
 import           Control.Arrow ( left )
 import           Control.Exception
-import           Control.Monad.Except
 import           Control.Monad.Identity
 import           Control.Monad.Logic
 import           Control.Monad.Reader
@@ -98,12 +97,14 @@ main = defaultMain $
 
     -- Ensure LogicT can be run over other base monads other than
     -- List.  Some are productive (Reader) and some are non-productive
-    -- (Except) in the observeAll case.
+    -- (ExceptT, ContT) in the observeAll case.
 
-    , testCase "runReader" $ [0..4] @=? (take 5 $ runReader (observeAllT nats) "!")
+    , testCase "runReader is productive" $
+      [0..4] @=? (take 5 $ runReader (observeAllT nats) "!")
 
-    , testCase "manyT runExceptT" $ [0..4] @=?
-      (either (const []) id $ runExcept (observeManyT 5 nats))
+    , testCase "observeManyT can be used with Either" $
+      (Right [0..4] :: Either Char [Integer]) @=?
+      (observeManyT 5 nats)
     ]
 
   --------------------------------------------------

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -6,6 +6,7 @@ module Main where
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
+import           Control.Arrow ( left )
 import           Control.Exception
 import           Control.Monad.Except
 import           Control.Monad.Identity
@@ -16,17 +17,13 @@ import qualified Control.Monad.State.Strict as SS
 import           Data.Maybe
 
 #if MIN_VERSION_base(4,9,0)
-import Data.Bifunctor ( first )
-import Test.Tasty.ExpectedFailure
+import           Test.Tasty.ExpectedFailure
 #if MIN_VERSION_base(4,11,0)
 #else
-import Data.Semigroup (Semigroup (..))
+import           Data.Semigroup (Semigroup (..))
 #endif
 #else
-import Data.Monoid
-first :: (a -> b) -> Either a c -> Either b c
-first _ (Right r) = Right r
-first f (Left x) = Left $ f x
+import           Data.Monoid
 #endif
 
 
@@ -453,4 +450,4 @@ main = defaultMain $
   ]
 
 safely :: IO Integer -> IO (Either String Integer)
-safely o = fmap (first (head . lines . show)) (try o :: IO (Either SomeException Integer))
+safely o = fmap (left (head . lines . show)) (try o :: IO (Either SomeException Integer))

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -5,8 +5,13 @@ module Main where
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import Control.Exception
+import Control.Monad.Except
+import Control.Monad.Identity
 import Control.Monad.Logic
 import Control.Monad.Reader
+import Data.Bifunctor ( first )
+import Data.Either
 
 monadReader1 :: Assertion
 monadReader1 = assertEqual "should be equal" [5 :: Int] $
@@ -22,8 +27,65 @@ monadReader2 = assertEqual "should be equal" [(5, 0)] $
       y <- ask
       return (x,y)
 
+monadReader3 :: Assertion
+monadReader3 = assertEqual "should be equal" [5,3] $
+  runReader (observeAllT (plus5 `mplus` mzero `mplus` plus3)) (0 :: Int)
+  where
+    plus5 = local (5+) ask
+    plus3 = local (3+) ask
+
+nats, odds5down :: Monad m => LogicT m Integer
+
+nats = pure 0 `mplus` ((1 +) <$> nats)
+
+odds5down = return 5 `mplus` mempty `mplus` mempty `mplus` return 3 `mplus` return 1
+
+yieldWords :: [String] -> LogicT m String
+yieldWords = go
+  where go [] = mzero
+        go (w:ws) = return w `mplus` go ws
+
+
 main :: IO ()
 main = defaultMain $ testGroup "All"
     [ testCase "Monad Reader 1" monadReader1
     , testCase "Monad Reader 2" monadReader2
+    , testCase "Monad Reader 3" monadReader3
+
+    , testCase "runIdentity all"  $ [0..4] @=? (take 5 $ runIdentity $ observeAllT nats)
+    , testCase "runIdentity many" $ [0..4] @=? (runIdentity $ observeManyT 5 nats)
+    , testCase "observeAll"       $ [0..4] @=? (take 5 $ observeAll nats)
+    , testCase "observeMany"      $ [0..4] @=? (observeMany 5 nats)
+
+    , testCase "runReader" $ [0..4] @=? (take 5 $ runReader (observeAllT nats) "!")
+
+    , testCase "manyT runExceptT" $ [0..4] @=?
+      (fromRight [] $ runExcept (observeManyT 5 nats))
+
+    , testCase "runLogicT multi" $ ["Hello world !"] @=?
+      let conc w o = ((w <> " ") <>) <$> o in
+      (runLogicT (yieldWords ["Hello", "world"]) conc (pure "!"))
+
+    , testCase "runLogicT none" $ ["!"] @=?
+      let conc w o = ((w <> " ") <>) <$> o in
+      (runLogicT (yieldWords []) conc (pure "!"))
+
+    , testCase "runLogicT first" $ ["Hello"] @=?
+      (runLogicT (yieldWords ["Hello", "world"]) (\w -> const $ return w) (return "!"))
+
+    , testCase "runLogic multi" $ 20 @=? runLogic odds5down (+) 11
+    , testCase "runLogic none"  $ 11 @=? runLogic mzero (+) (11 :: Integer)
+
+    , testCase "observe multi" $ 5 @=? observe odds5down
+    , testCase "observe none" $ (Left "No answer." @=?) =<< safely (observe mzero)
+
+    , testCase "observeAll multi" $ [5,3,1] @=? observeAll odds5down
+    , testCase "observeAll none" $ ([] :: [Integer]) @=? observeAll mzero
+
+    , testCase "observeMany multi" $ [5,3] @=? observeMany 2 odds5down
+    , testCase "observeMany none" $ ([] :: [Integer]) @=? observeMany 2 mzero
+
     ]
+
+safely :: IO Integer -> IO (Either String Integer)
+safely o = first (head . lines . show) <$> (try o :: IO (Either SomeException Integer))

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -16,8 +16,11 @@ import qualified Control.Monad.State.Lazy as SL
 import qualified Control.Monad.State.Strict as SS
 import           Data.Maybe
 
-#if MIN_VERSION_base(4,9,0)
+#ifdef MIN_VERSION_tasty_expected_failure
 import           Test.Tasty.ExpectedFailure
+#endif
+
+#if MIN_VERSION_base(4,9,0)
 #if MIN_VERSION_base(4,11,0)
 #else
 import           Data.Semigroup (Semigroup (..))
@@ -220,7 +223,7 @@ main = defaultMain $
         -- terminate (there are none, since the first clause generates
         -- an infinity of mzero "failures")
 
-#if MIN_VERSION_base(4,9,0)
+#ifdef MIN_VERSION_tasty_expected_failure
       , expectFail $ testCase "nontermination even when fair" $
         [[2]] @=? observeManyT 2 oddsOrTwo
 #endif
@@ -259,7 +262,7 @@ main = defaultMain $
         -- unfair conjunction does not terminate or produce any
         -- values: this will fail (expectedly) due to a timeout
 
-#if MIN_VERSION_base(4,9,0)
+#ifdef MIN_VERSION_tasty_expected_failure
       , expectFail $ testCase "unfair conjunction" $ [2,4,6,8] @=?
         observeMany 4 (let oddsPlus n = odds >>= \a -> return (a + n) in
                        do x <- (return 0 `mplus` return 1) >>= oddsPlus

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -2,16 +2,19 @@
 
 module Main where
 
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
-import Control.Exception
-import Control.Monad.Except
-import Control.Monad.Identity
-import Control.Monad.Logic
-import Control.Monad.Reader
-import Data.Bifunctor ( first )
-import Data.Either
+import           Control.Exception
+import           Control.Monad.Except
+import           Control.Monad.Identity
+import           Control.Monad.Logic
+import           Control.Monad.Reader
+import qualified Control.Monad.State.Lazy as SL
+import qualified Control.Monad.State.Strict as SS
+import           Data.Bifunctor ( first )
+import           Data.Either
+import           Data.Maybe
 
 monadReader1 :: Assertion
 monadReader1 = assertEqual "should be equal" [5 :: Int] $
@@ -48,11 +51,15 @@ yieldWords = go
 
 main :: IO ()
 main = defaultMain $ testGroup "All"
+  [ testGroup "Monad Reader + env"
     [ testCase "Monad Reader 1" monadReader1
     , testCase "Monad Reader 2" monadReader2
     , testCase "Monad Reader 3" monadReader3
+    ]
 
-    , testCase "runIdentity all"  $ [0..4] @=? (take 5 $ runIdentity $ observeAllT nats)
+  , testGroup "Various monads"
+    [
+      testCase "runIdentity all"  $ [0..4] @=? (take 5 $ runIdentity $ observeAllT nats)
     , testCase "runIdentity many" $ [0..4] @=? (runIdentity $ observeManyT 5 nats)
     , testCase "observeAll"       $ [0..4] @=? (take 5 $ observeAll nats)
     , testCase "observeMany"      $ [0..4] @=? (observeMany 5 nats)
@@ -61,8 +68,11 @@ main = defaultMain $ testGroup "All"
 
     , testCase "manyT runExceptT" $ [0..4] @=?
       (fromRight [] $ runExcept (observeManyT 5 nats))
+    ]
 
-    , testCase "runLogicT multi" $ ["Hello world !"] @=?
+  , testGroup "Control.Monad.Logic tests"
+    [
+      testCase "runLogicT multi" $ ["Hello world !"] @=?
       let conc w o = ((w <> " ") <>) <$> o in
       (runLogicT (yieldWords ["Hello", "world"]) conc (pure "!"))
 
@@ -84,8 +94,70 @@ main = defaultMain $ testGroup "All"
 
     , testCase "observeMany multi" $ [5,3] @=? observeMany 2 odds5down
     , testCase "observeMany none" $ ([] :: [Integer]) @=? observeMany 2 mzero
+    ]
+
+  , testGroup "Control.Monad.Logic.Class tests"
+    [
+      testGroup "msplit laws"
+      [
+        testGroup "msplit mzero == return Nothing"
+        [
+          testCase "msplit mzero == return Nothing :: []" $
+          msplit mzero @=? return (Nothing :: Maybe (String, [String]))
+        , testCase "msplit mzero == return Nothing :: ReaderT" $
+          let z :: ReaderT Int [] String
+              z = mzero
+          in assertBool "ReaderT" $ null $ catMaybes $ runReaderT (msplit z) 0
+        , testCase "msplit mzero == return Nothing :: LogicT" $
+          let z :: LogicT [] String
+              z = mzero
+          in assertBool "LogicT" $ null $ catMaybes $ concat $ observeAllT (msplit z)
+        , testCase "msplit mzero == return Nothing :: strict StateT" $
+          let z :: SS.StateT Int [] String
+              z = mzero
+          in assertBool "strict StateT" $ null $ catMaybes $ SS.evalStateT (msplit z) 0
+        , testCase "msplit mzero == return Nothing :: lazy StateT" $
+          let z :: SL.StateT Int [] String
+              z = mzero
+          in assertBool "lazy StateT" $ null $ catMaybes $ SL.evalStateT (msplit z) 0
+        ]
+
+      , testGroup "msplit (return a `mplus` m) == return (Just a, m)" $
+        let sample = [1::Integer,2,3] in
+        [
+          testCase "msplit []" $ do
+            let op = sample
+                extract = fmap (fmap fst)
+            extract (msplit op) @?= [Just 1]
+            extract (msplit op >>= (\(Just (_,nxt)) -> msplit nxt)) @?= [Just 2]
+        , testCase "msplit ReaderT" $ do
+            let op = ask
+                extract = fmap fst . catMaybes . flip runReaderT sample
+            extract (msplit op) @?= [sample]
+            extract (msplit op >>= (\(Just (_,nxt)) -> msplit nxt)) @?= []
+        , testCase "msplit LogicT" $ do
+            let op :: LogicT [] Integer
+                op = foldr (mplus . return) mzero sample
+                extract = fmap fst . catMaybes . concat . observeAllT
+            extract (msplit op) @?= [1]
+            extract (msplit op >>= (\(Just (_,nxt)) -> msplit nxt)) @?= [2]
+        , testCase "msplit strict StateT" $ do
+            let op :: SS.StateT Integer [] Integer
+                op = (SS.modify (+1) >> SS.get `mplus` op)
+                extract = fmap fst . catMaybes . flip SS.evalStateT 0
+            extract (msplit op) @?= [1]
+            extract (msplit op >>= \(Just (_,nxt)) -> msplit nxt) @?= [2]
+        , testCase "msplit lazy StateT" $ do
+            let op :: SL.StateT Integer [] Integer
+                op = (SL.modify (+1) >> SL.get `mplus` op)
+                extract = fmap fst . catMaybes . flip SL.evalStateT 0
+            extract (msplit op) @?= [1]
+            extract (msplit op >>= \(Just (_,nxt)) -> msplit nxt) @?= [2]
+        ]
+      ]
 
     ]
+  ]
 
 safely :: IO Integer -> IO (Either String Integer)
 safely o = first (head . lines . show) <$> (try o :: IO (Either SomeException Integer))

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -55,7 +55,7 @@ nats, odds, oddsOrTwo,
   oddsOrTwoUnfair, oddsOrTwoFair,
   odds5down :: Monad m => LogicT m Integer
 
-#if MIN_VERSION_base(4,6,0)
+#if MIN_VERSION_base(4,8,0)
 nats = pure 0 `mplus` ((1 +) <$> nats)
 #else
 nats = return 0 `mplus` liftM (1 +) nats


### PR DESCRIPTION
Adds tests for Logic/LogicT as well as the various instances of Control.Monad.Logic.Class.  These are documented and hopefully serve to show some additional examples of the use of the logict package.

Many of the test sample code segments are taken from the paper cited in the README.