### PR TITLE
Add RebindableSyntax test for fair conjunction (fails).

### DIFF
--- a/logict.cabal
+++ b/logict.cabal
@@ -46,6 +46,7 @@ test-suite logict-tests
   main-is: Test.hs
   default-language: Haskell2010
   ghc-options: -Wall
+  other-modules: TestRebindableSyntax
   build-depends:
     base >=2 && <5,
     logict -any,

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -28,6 +28,8 @@ import           Data.Semigroup (Semigroup (..))
 import           Data.Monoid
 #endif
 
+import           TestRebindableSyntax
+
 
 monadReader1 :: Assertion
 monadReader1 = assertEqual "should be equal" [5 :: Int] $
@@ -259,6 +261,9 @@ main = defaultMain $
                        do x <- (return 0 `mplus` return 1) >>- oddsPlus
                           if even x then return x else mzero
                       )
+
+      , testCase "fair conjunction, rebindable syntax, monadic" $
+        [2,4,6,8] @=? observeMany 4 oddsPlusRSBind
 
         -- unfair conjunction does not terminate or produce any
         -- values: this will fail (expectedly) due to a timeout

--- a/test/TestRebindableSyntax.hs
+++ b/test/TestRebindableSyntax.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE RebindableSyntax #-}
+
+module TestRebindableSyntax where
+
+import Control.Monad.Logic
+
+import Prelude
+
+
+oddsAppl :: LogicT m Integer
+oddsAppl = return 1 `mplus` liftM (2+) oddsAppl
+
+oddsPlus' :: Integer -> LogicT m Integer
+oddsPlus' n = oddsAppl >>= \a -> return (a + n)
+
+oddsPlusRSBind :: Monad m => LogicT m Integer
+oddsPlusRSBind =
+  do
+     -- Desugaring of do should combine these with >>-
+     a <- (return 0 `mplus` return 1)
+     x <- oddsPlus' a
+
+     -- This is the explicit form
+     -- x <- (return 0 `interleave` return 1) >>- oddsPlus'
+
+     if even x then return x else mzero
+  where (>>=) = (>>-)
+
+
+-- Because rebindable syntax was used, this must be explicitly provided:
+ifThenElse :: Bool -> a -> a -> a
+ifThenElse c t e = case c of { True -> t; False -> e }


### PR DESCRIPTION
This is the attempt at using RebindableSyntax that I was talking about.  

It does not work.  If you uncomment the explicit form and comment out the implicit form, the test passes.  Examining the desugared core (-ddump-ds), I can see the let binding of >>= to >>- in the core, but it's apparently not happening at a point where the default definition of >>- is able to be applied to the terms (the terms still use mplus instead of interleave).

My thought was that a RULES application might help, but that has several downsides:
* RULES require the removal of the `{-# LANGUAGE Safe #-}` declarations in both modules
* RULES require builds with optimization in order to be utilized
* I couldn't get the rule matching to work

I'm providing this here based on our discussion on the other PR where this was expected to work.  Hopefully I've just made some smple mistake in my attempt to use RebindableSyntax, but otherwise I don't know there's much more to do, so this PR is more for communicating my attempt and feel free to close it unless you can make it work.