### PR TITLE
Use async concurrent timeout for more reliable test timeouts.

### DIFF
--- a/logict.cabal
+++ b/logict.cabal
@@ -54,14 +54,10 @@ test-suite logict-tests
   ghc-options: -Wall
   build-depends:
     base >=2 && <5,
+    async,
     logict -any,
     mtl,
     tasty,
     tasty-hunit
-
-  if impl(ghc >= 8.0)
-    build-depends:
-      tasty-expected-failure >= 0.12,
-      async
 
   hs-source-dirs: test

--- a/logict.cabal
+++ b/logict.cabal
@@ -61,6 +61,7 @@ test-suite logict-tests
 
   if impl(ghc >= 8.0)
     build-depends:
-      tasty-expected-failure >= 0.12
+      tasty-expected-failure >= 0.12,
+      async
 
   hs-source-dirs: test

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -7,6 +7,8 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 
 import           Control.Arrow ( left )
+import           Control.Concurrent ( threadDelay )
+import           Control.Concurrent.Async ( race )
 import           Control.Exception
 import           Control.Monad.Identity
 import           Control.Monad.Logic
@@ -14,12 +16,6 @@ import           Control.Monad.Reader
 import qualified Control.Monad.State.Lazy as SL
 import qualified Control.Monad.State.Strict as SS
 import           Data.Maybe
-
-#ifdef MIN_VERSION_tasty_expected_failure
-import           Control.Concurrent ( threadDelay )
-import           Control.Concurrent.Async ( race )
-import           Test.Tasty.ExpectedFailure
-#endif
 
 #if MIN_VERSION_base(4,9,0)
 #if MIN_VERSION_base(4,11,0)
@@ -226,10 +222,8 @@ main = defaultMain $
         -- terminate (there are none, since the first clause generates
         -- an infinity of mzero "failures")
 
-#ifdef MIN_VERSION_tasty_expected_failure
-      , expectFail $ testCase "nontermination even when fair" $
-        (Right [2] @=?) =<< (nonTerminating $ observeManyT 2 oddsOrTwo)
-#endif
+      , testCase "NONTERMINATION even when fair" $
+        (Left () @=?) =<< (nonTerminating $ observeManyT 2 oddsOrTwo)
 
         -- Validate fair disjunction works for other
         -- Control.Monad.Logic.Class instances
@@ -299,44 +293,38 @@ main = defaultMain $
         -- between those values, but the first (oddsPlus 0 ...) never
         -- produces any values.
 
-#ifdef MIN_VERSION_tasty_expected_failure
-      , expectFail $ testCase "fair conjunction non-productive" $
-        (Right [2,4,6,8] @=?) =<<
+      , testCase "fair conjunction NON-PRODUCTIVE" $
+        (Left () @=?) =<<
         (nonTerminating $
          observeManyT 4 (let oddsPlus n = odds >>= \a -> return (a + n) in
                            (return 0 `mplus` return 1) >>-
                            \a -> oddsPlus a >>-
                                  (\x -> if even x then return x else mzero)
                         ))
-#endif
 
         -- This shows that the second >>- is effectively >>= since
         -- there's no choice point for it, and values still cannot be
         -- produced.
 
-#ifdef MIN_VERSION_tasty_expected_failure
-      , expectFail $ testCase "fair conjunction also non-productive" $
-        (Right [2,4,6,8] @=?) =<<
+      , testCase "fair conjunction also NON-PRODUCTIVE" $
+        (Left () @=?) =<<
         (nonTerminating $
          observeManyT 4 (let oddsPlus n = odds >>= \a -> return (a + n) in
                            (return 0 `mplus` return 1) >>-
                            \a -> oddsPlus a >>=
                                  (\x -> if even x then return x else mzero)
                         ))
-#endif
 
         -- unfair conjunction does not terminate or produce any
         -- values: this will fail (expectedly) due to a timeout
 
-#ifdef MIN_VERSION_tasty_expected_failure
-      , expectFail $ testCase "unfair conjunction" $
-        (Right [2,4,6,8] @=?) =<<
+      , testCase "unfair conjunction is NON-PRODUCTIVE" $
+        (Left () @=?) =<<
         (nonTerminating $
          observeManyT 4 (let oddsPlus n = odds >>= \a -> return (a + n) in
                            do x <- (return 0 `mplus` return 1) >>= oddsPlus
                               if even x then return x else mzero
                         ))
-#endif
 
       , testCase "fair conjunction :: []" $ [2,4,6,8] @=?
         (take 4 $ let oddsL = [ 1 :: Integer ] `mplus` [ o | o <- [3..], odd o ]
@@ -523,7 +511,10 @@ main = defaultMain $
 safely :: IO Integer -> IO (Either String Integer)
 safely o = fmap (left (head . lines . show)) (try o :: IO (Either SomeException Integer))
 
-#ifdef MIN_VERSION_tasty_expected_failure
+-- | This is used to test logic operations that don't typically
+-- terminate by running a parallel race between the operation and a
+-- timer.  A result of @Left ()@ means that the timer won and the
+-- operation did not terminate within that time period.
+
 nonTerminating :: IO a -> IO (Either () a)
 nonTerminating op = race (threadDelay 100000) op  -- returns Left () after 0.1s
-#endif

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -523,5 +523,7 @@ main = defaultMain $
 safely :: IO Integer -> IO (Either String Integer)
 safely o = fmap (left (head . lines . show)) (try o :: IO (Either SomeException Integer))
 
+#ifdef MIN_VERSION_tasty_expected_failure
 nonTerminating :: IO a -> IO (Either () a)
 nonTerminating op = race (threadDelay 100000) op  -- returns Left () after 0.1s
+#endif


### PR DESCRIPTION
I don't have access to the failing test environments, but hopefully this will be a more reliable timeout methodology for non-productive/non-terminating tests than the tasty/tasty-expected-failure timeout attempts.