### PR TITLE
Fix ifte example

### DIFF
--- a/Control/Monad/Logic/Class.hs
+++ b/Control/Monad/Logic/Class.hs
@@ -291,8 +291,8 @@ class (Monad m, Alternative m) => MonadLogic m where
     --   >                 pure d
     --   >
     --   > prime v = once (ifte (divisors v)
-    --   >                   (const (pure True))
-    --   >                   (pure False))
+    --   >                   (const (pure False))
+    --   >                   (pure True))
     --
     --   >>> observeAll (prime 20)
     --   [False]


### PR DESCRIPTION
A number is prime if it *doesn't* have any (non-trivial) divisors.