### PR TITLE
Add conversion functions

### DIFF
--- a/Control/Monad/Logic.hs
+++ b/Control/Monad/Logic.hs
@@ -45,6 +45,7 @@ module Control.Monad.Logic (
     observeAllT,
     fromLogicT,
     fromLogicTWith,
+    hoistLogicT,
     module Control.Monad,
     module Trans
   ) where
@@ -174,6 +175,7 @@ fromLogicT = fromLogicTWith lift
 
 -- | Convert from @'LogicT' m@ to an arbitrary logic-like monad,
 -- such as @[]@.
+--
 -- The first argument should be a
 -- <https://hackage.haskell.org/package/mmorph/docs/Control-Monad-Morph.html monad morphism>.
 -- to produce sensible results.
@@ -181,6 +183,19 @@ fromLogicTWith :: (Applicative m, Monad n, Alternative n)
   => (forall x. m x -> n x) -> LogicT m a -> n a
 fromLogicTWith p (LogicT f) = join . p $
   f (\a v -> pure (pure a <|> join (p v))) (pure empty)
+
+-- | Convert a 'LogicT' computation from one underlying monad to another.
+-- For example,
+--
+-- @
+-- hoistLogicT lift :: LogicT m a -> LogicT (StateT m) a
+-- @
+--
+-- The first argument should be a
+-- <https://hackage.haskell.org/package/mmorph/docs/Control-Monad-Morph.html monad morphism>.
+-- to produce sensible results.
+hoistLogicT :: (Applicative m, Monad n) => (forall x. m x -> n x) -> LogicT m a -> LogicT n a
+hoistLogicT f = fromLogicTWith (lift . f)
 
 -------------------------------------------------------------------------
 -- | The basic 'Logic' monad, for performing backtracking computations

--- a/Control/Monad/Logic.hs
+++ b/Control/Monad/Logic.hs
@@ -43,6 +43,8 @@ module Control.Monad.Logic (
     observeT,
     observeManyT,
     observeAllT,
+    fromLogicT,
+    fromLogicTWith,
     module Control.Monad,
     module Trans
   ) where
@@ -158,6 +160,27 @@ observeManyT n m
 --
 runLogicT :: LogicT m a -> (a -> m r -> m r) -> m r -> m r
 runLogicT (LogicT r) = r
+
+-- | Convert from 'LogicT' to an arbitrary logic-like monad transformer,
+-- such as <https://hackage.haskell.org/package/logict-sequence logict-sequence>
+#if MIN_VERSION_base(4,8,0)
+fromLogicT :: (Alternative (t m), MonadTrans t, Monad m, Monad (t m))
+  => LogicT m a -> t m a
+#else
+fromLogicT :: (Alternative (t m), MonadTrans t, Applicative m, Monad m, Monad (t m))
+  => LogicT m a -> t m a
+#endif
+fromLogicT = fromLogicTWith lift
+
+-- | Convert from @'LogicT' m@ to an arbitrary logic-like monad,
+-- such as @[]@.
+-- The first argument should be a
+-- <https://hackage.haskell.org/package/mmorph/docs/Control-Monad-Morph.html monad morphism>.
+-- to produce sensible results.
+fromLogicTWith :: (Applicative m, Monad n, Alternative n)
+  => (forall x. m x -> n x) -> LogicT m a -> n a
+fromLogicTWith p (LogicT f) = join . p $
+  f (\a v -> pure (pure a <|> join (p v))) (pure empty)
 
 -------------------------------------------------------------------------
 -- | The basic 'Logic' monad, for performing backtracking computations

--- a/Control/Monad/Logic.hs
+++ b/Control/Monad/Logic.hs
@@ -46,6 +46,7 @@ module Control.Monad.Logic (
     fromLogicT,
     fromLogicTWith,
     hoistLogicT,
+    embedLogicT,
     module Control.Monad,
     module Trans
   ) where
@@ -176,6 +177,14 @@ fromLogicT = fromLogicTWith lift
 -- | Convert from @'LogicT' m@ to an arbitrary logic-like monad,
 -- such as @[]@.
 --
+-- Examples:
+--
+-- @
+-- 'fromLogicT' = fromLogicTWith d
+-- 'hoistLogicT' f = fromLogicTWith ('lift' . f)
+-- 'embedLogicT' f = 'fromLogicTWith' f
+-- @
+--
 -- The first argument should be a
 -- <https://hackage.haskell.org/package/mmorph/docs/Control-Monad-Morph.html monad morphism>.
 -- to produce sensible results.
@@ -196,6 +205,14 @@ fromLogicTWith p (LogicT f) = join . p $
 -- to produce sensible results.
 hoistLogicT :: (Applicative m, Monad n) => (forall x. m x -> n x) -> LogicT m a -> LogicT n a
 hoistLogicT f = fromLogicTWith (lift . f)
+
+-- | Convert a 'LogicT' computation from one underlying monad to another.
+--
+-- The first argument should be a
+-- <https://hackage.haskell.org/package/mmorph/docs/Control-Monad-Morph.html monad morphism>.
+-- to produce sensible results.
+embedLogicT :: Applicative m => (forall a. m a -> LogicT n a) -> LogicT m b -> LogicT n b
+embedLogicT f = fromLogicTWith f
 
 -------------------------------------------------------------------------
 -- | The basic 'Logic' monad, for performing backtracking computations


### PR DESCRIPTION
We can convert from `LogicT` to any other logic-like monad or
monad transformer, so let's do that.

We can also export a generalization that takes an arbitrary monad morphism, and also use that to implement a version of `hoist`. So let's do all that.

Closes #26