### PR TITLE
feat: instance `MonadLogic` for `WriterT`

### DIFF
--- a/logict.cabal
+++ b/logict.cabal
@@ -40,11 +40,12 @@ library
 
   build-depends:
     base >=4.3 && <5,
-    mtl >=2.0 && <2.4
+    mtl >=2.0 && <2.4,
+    transformers
 
   if impl(ghc <8.0)
     build-depends:
-      fail, transformers
+      fail
 
 executable grandparents
   buildable: False
@@ -69,6 +70,7 @@ test-suite logict-tests
     async >=2.0,
     logict,
     mtl,
+    transformers,
     tasty,
     tasty-hunit
 


### PR DESCRIPTION
I have implemented `MonadLogic` in `WriterT` as well.

Until now, `WriterT` should not be used because it easily causes space leaks. However, [Control.Monad.Trans.Writer.CPS](https://www.stackage.org/haddock/nightly-2022-12-08/transformers-0.5.6.2/Control-Monad-Trans-Writer-CPS.html) no longer causes space leaks and can be used. Therefore, we would like to use `WriterT`, but it is inconvenient if it cannot be combined with `MonadLogic`.

Therefore, I implemented it and added tests where `ReaderT` and `StateT` are tested.

To use the CPS version of `WriterT`, I raised the mtl version requirement to [feat(Control.Monad.Writer.CPS): re export runWriterT by ncaq · Pull Request #136 · haskell/mtl](https://github.com/haskell/mtl/pull/136) has not yet been imported, so we have no choice but to rely directly on transformers. In the end, mtl depends on transformers, so we have determined that this is not a critical problem. We have taken care to make it easy to remove them when they are no longer needed by doing a limited `import`.

I was surprised myself that many of the CPP macros in the test code were removed. It was not my intention.
I believe it was probably done by the HLS plugin.
I've been trying to find out why it deleted them. I found out that the new mtl raises the lower limit for the base library in the cabal file. So when raising the lower version limit of mtl, we thought that it is certainly not a very effective practice to control the base version here. Therefore, we decided to leave the deleted part as it is.