### PR TITLE
build: add `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+### Haskell ###
+dist
+dist-*
+cabal-dev
+*.o
+*.hi
+*.hie
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
+.stack-work/
+cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*


### PR DESCRIPTION
What
===

I add `.gitignore` from <https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Haskell.gitignore>.

Why
===

I was getting depressed with the `dist-newstyle` being tracked in Git every time I did a `cabal build` or something like that. This is a list of paths that should typically be ignored when developing in Haskell, and I think it is appropriate for all developers developing on this project. Strictly speaking, this project does not seem to use Stack, etc., but since it would be troublesome to go to the trouble of modifying the files managed by GitHub, I have copied them as they are, since no bad side effects would occur if they were excluded separately.