### PR TITLE
feat: add `instance` for `MonadThrow` and `MonadCatch`

### DIFF
--- a/logict.cabal
+++ b/logict.cabal
@@ -41,7 +41,8 @@ library
   build-depends:
     base >=4.3 && <5,
     mtl >=2.0 && <2.4,
-    transformers <0.7
+    transformers <0.7,
+    exceptions
 
   if impl(ghc <8.0)
     build-depends:


### PR DESCRIPTION
Since writing with `MonadThrow` has recently become popular, especially in the rio community, we thought it would be useful to have it. The implementation is already similar in `MonadError`, so we thought it would be good to just use that.